### PR TITLE
Add Playwright API testing example with fixtures

### DIFF
--- a/pages/postsApi.ts
+++ b/pages/postsApi.ts
@@ -1,0 +1,12 @@
+import {APIRequestContext} from "@playwright/test";
+
+export class PostsApi {
+
+    constructor(private readonly request: APIRequestContext) {
+
+    }
+
+    async returnStorageState() {
+        return this.request.storageState();
+    }
+}

--- a/pages/startPage.ts
+++ b/pages/startPage.ts
@@ -1,0 +1,20 @@
+import { Locator, Page } from "@playwright/test";
+
+export class StartPage {
+    private readonly guideButton: Locator;
+    private readonly sponsorThisProjectButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.guideButton = this.page.getByRole('link', { name: 'Guide', exact: true });
+        this.sponsorThisProjectButton = this.page.getByRole('link', { name: 'Sponsor this project', exact: true });
+    }
+
+    async clickOnGuideButton() {
+        await this.guideButton.click();
+    }
+
+    async clickOnSponsorThisProjectButton() {
+        await this.sponsorThisProjectButton.click();
+    }
+
+}

--- a/pages/testFixtures.ts
+++ b/pages/testFixtures.ts
@@ -1,14 +1,20 @@
 import { test as base } from 'pw-api-plugin';
 import {StartPage} from "./startPage";
+import {PostsApi} from "./postsApi";
 
 type MyFixtures = {
     startPage: StartPage;
+    postsApi: PostsApi
 };
 
 export const test = base.extend<MyFixtures>({
     startPage: async ({page}, use) => {
         await use(new StartPage(page))
     },
+
+    postsApi: async ({request}, use) => {
+        await use(new PostsApi(request))
+    }
 
 });
 export { expect } from '@playwright/test';

--- a/pages/testFixtures.ts
+++ b/pages/testFixtures.ts
@@ -1,0 +1,15 @@
+import { test as base } from 'pw-api-plugin';
+import {StartPage} from "./startPage";
+
+type MyFixtures = {
+    startPage: StartPage;
+};
+
+export const test = base.extend<MyFixtures>({
+    startPage: async ({page}, use) => {
+        await use(new StartPage(page))
+    },
+
+});
+export { expect } from '@playwright/test';
+export { pwApi } from 'pw-api-plugin';

--- a/tests/playwright-api/pwApi-fixtures-example.spec.ts
+++ b/tests/playwright-api/pwApi-fixtures-example.spec.ts
@@ -4,22 +4,22 @@ test.describe('PW-API-PLUGIN PLAYWRIGHT API Tests for https://jsonplaceholder.ty
 
     const baseUrl = 'https://jsonplaceholder.typicode.com';
 
-    test('Verify pwApi GET, HEAD, POST, PUT, PATCH, DELETE in single test', async ({ request, startPage }) => {
+    test('Verify pwApi GET, HEAD, POST, PUT, PATCH, DELETE in single test', async ({ postsApi, startPage }) => {
 
         // ✔️ Example of get
-        const responseGet = await pwApi.get({ request, startPage }, `${baseUrl}/posts/1`)
+        const responseGet = await pwApi.get({ postsApi, startPage }, `${baseUrl}/posts/1`)
         expect(responseGet.status()).toBe(200)
         const responseBodyGet = await responseGet.json()
         expect(responseBodyGet).toHaveProperty('id', 1)
 
 
         // ✔️ Example of head
-        const responseHead = await pwApi.head({ request, startPage }, `${baseUrl}/posts/1`)
+        const responseHead = await pwApi.head({ postsApi, startPage }, `${baseUrl}/posts/1`)
         expect(responseHead.status()).toBe(200)
 
 
         // ✔️ Example of post (with request body and request headers)
-        const responsePost = await pwApi.post({ request, startPage }, `${baseUrl}/posts`,
+        const responsePost = await pwApi.post({ postsApi, startPage }, `${baseUrl}/posts`,
             {
                 data: {
                     title: 'foo',
@@ -37,7 +37,7 @@ test.describe('PW-API-PLUGIN PLAYWRIGHT API Tests for https://jsonplaceholder.ty
 
 
         // ✔️ Example of put (with request: body, headers, params, timeout, maxRetries)
-        const responsePut = await pwApi.put({ request, startPage }, 'https://jsonplaceholder.typicode.com/posts/1',
+        const responsePut = await pwApi.put({ postsApi, startPage }, 'https://jsonplaceholder.typicode.com/posts/1',
             {
                 data: {
                     id: 1,
@@ -59,7 +59,7 @@ test.describe('PW-API-PLUGIN PLAYWRIGHT API Tests for https://jsonplaceholder.ty
 
 
         // ✔️ Example of patch (with request body and request headers)
-        const responsePatch = await pwApi.patch({ request, startPage }, 'https://jsonplaceholder.typicode.com/posts/1',
+        const responsePatch = await pwApi.patch({ postsApi, startPage }, 'https://jsonplaceholder.typicode.com/posts/1',
             {
                 data: {
                     title: 'hello',
@@ -73,16 +73,16 @@ test.describe('PW-API-PLUGIN PLAYWRIGHT API Tests for https://jsonplaceholder.ty
 
 
         // ✔️ Example for delete
-        const responseDelete = await pwApi.delete({ request, startPage }, 'https://jsonplaceholder.typicode.com/posts/1');
+        const responseDelete = await pwApi.delete({ postsApi, startPage }, 'https://jsonplaceholder.typicode.com/posts/1');
         expect(responseDelete.ok()).toBeTruthy()
 
     })
 
 
-    test('Verify pwApi FETCH (using default GET)', async ({ request, startPage }) => {
+    test('Verify pwApi FETCH (using default GET)', async ({ postsApi, startPage }) => {
 
         // ✔️ Example fetch (default GET)
-        const responseFetch = await pwApi.fetch({ request, startPage }, `${baseUrl}/posts`);
+        const responseFetch = await pwApi.fetch({ postsApi, startPage }, `${baseUrl}/posts`);
         expect(responseFetch.status()).toBe(200)
         const responseBodyFetch = await responseFetch.json()
         expect(responseBodyFetch.length).toBeGreaterThan(4)
@@ -90,10 +90,10 @@ test.describe('PW-API-PLUGIN PLAYWRIGHT API Tests for https://jsonplaceholder.ty
     })
 
 
-    test('Verify pwApi for Failing GET Method (404)', async ({ request, startPage }) => {
+    test('Verify pwApi for Failing GET Method (404)', async ({ postsApi, startPage }) => {
 
         // ❌ Example for get with wrong URL
-        const responseFetch = await pwApi.get({ request, startPage }, `${baseUrl}/this-is-a-non-sense-endpoint`)
+        const responseFetch = await pwApi.get({ postsApi, startPage }, `${baseUrl}/this-is-a-non-sense-endpoint`)
         expect(responseFetch.status()).toBe(404)
 
     })

--- a/tests/playwright-api/pwApi-fixtures-example.spec.ts
+++ b/tests/playwright-api/pwApi-fixtures-example.spec.ts
@@ -1,0 +1,100 @@
+import {expect, pwApi, test} from "../../pages/testFixtures";
+
+test.describe('PW-API-PLUGIN PLAYWRIGHT API Tests for https://jsonplaceholder.typicode.com', () => {
+
+    const baseUrl = 'https://jsonplaceholder.typicode.com';
+
+    test('Verify pwApi GET, HEAD, POST, PUT, PATCH, DELETE in single test', async ({ request, startPage }) => {
+
+        // ✔️ Example of get
+        const responseGet = await pwApi.get({ request, startPage }, `${baseUrl}/posts/1`)
+        expect(responseGet.status()).toBe(200)
+        const responseBodyGet = await responseGet.json()
+        expect(responseBodyGet).toHaveProperty('id', 1)
+
+
+        // ✔️ Example of head
+        const responseHead = await pwApi.head({ request, startPage }, `${baseUrl}/posts/1`)
+        expect(responseHead.status()).toBe(200)
+
+
+        // ✔️ Example of post (with request body and request headers)
+        const responsePost = await pwApi.post({ request, startPage }, `${baseUrl}/posts`,
+            {
+                data: {
+                    title: 'foo',
+                    body: 'bar',
+                    userId: 1,
+                },
+                headers: {
+                    'Content-type': 'application/json; charset=UTF-8',
+                },
+            }
+        );
+        expect(responsePost.status()).toBe(201)
+        const responseBodyPost = await responsePost.json()
+        expect(responseBodyPost).toHaveProperty('id', 101)
+
+
+        // ✔️ Example of put (with request: body, headers, params, timeout, maxRetries)
+        const responsePut = await pwApi.put({ request, startPage }, 'https://jsonplaceholder.typicode.com/posts/1',
+            {
+                data: {
+                    id: 1,
+                    title: 'foo',
+                    body: 'bar',
+                    userId: 1,
+                },
+                headers: {
+                    'Content-type': 'application/json; charset=UTF-8',
+                },
+                params: { _limit: 1000, _details: true },
+                timeout: 2000,
+                maxRetries: 1
+            }
+        )
+        expect(responsePut.ok()).toBeTruthy()
+        const responseBodyPut = await responsePut.json()
+        expect(responseBodyPut).toHaveProperty('id', 1)
+
+
+        // ✔️ Example of patch (with request body and request headers)
+        const responsePatch = await pwApi.patch({ request, startPage }, 'https://jsonplaceholder.typicode.com/posts/1',
+            {
+                data: {
+                    title: 'hello',
+                },
+                headers: {
+                    'Content-type': 'application/json; charset=UTF-8',
+                },
+            }
+        );
+        expect(responsePatch.ok()).toBeTruthy()
+
+
+        // ✔️ Example for delete
+        const responseDelete = await pwApi.delete({ request, startPage }, 'https://jsonplaceholder.typicode.com/posts/1');
+        expect(responseDelete.ok()).toBeTruthy()
+
+    })
+
+
+    test('Verify pwApi FETCH (using default GET)', async ({ request, startPage }) => {
+
+        // ✔️ Example fetch (default GET)
+        const responseFetch = await pwApi.fetch({ request, startPage }, `${baseUrl}/posts`);
+        expect(responseFetch.status()).toBe(200)
+        const responseBodyFetch = await responseFetch.json()
+        expect(responseBodyFetch.length).toBeGreaterThan(4)
+
+    })
+
+
+    test('Verify pwApi for Failing GET Method (404)', async ({ request, startPage }) => {
+
+        // ❌ Example for get with wrong URL
+        const responseFetch = await pwApi.get({ request, startPage }, `${baseUrl}/this-is-a-non-sense-endpoint`)
+        expect(responseFetch.status()).toBe(404)
+
+    })
+})


### PR DESCRIPTION
For fixtures it looks like that: ![image](https://github.com/user-attachments/assets/cbf7cf31-e8e6-481f-b07f-4aaf967fe6b7)
